### PR TITLE
Build using setuptools natively

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "pybind11"]
-	path = pybind11
-	url = https://github.com/pybind/pybind11.git
 [submodule "googletest"]
 	path = googletest
 	url = https://github.com/google/googletest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "pybind11"]
+	path = pybind11
+	url = https://github.com/pybind/pybind11.git
 [submodule "googletest"]
 	path = googletest
 	url = https://github.com/google/googletest.git

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you are not using `conda` then please install from source:
 ```
 git clone git@github.com:bobfang1992/pytomlpp.git
 cd pytomlpp
-python setup.py install
+pip install .
 ```
 
 ## Why not pypi?

--- a/setup.py
+++ b/setup.py
@@ -1,64 +1,12 @@
-import os
-import re
-import sys
-import platform
-import subprocess
-
 from setuptools import setup, Extension
-from setuptools.command.build_ext import build_ext
-from distutils.version import LooseVersion
 
 
-class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=''):
-        Extension.__init__(self, name, sources=[])
-        self.sourcedir = os.path.abspath(sourcedir)
+class PyBind11Include:
+    def __str__(self):
+        import pybind11
 
+        return pybind11.get_include()
 
-class CMakeBuild(build_ext):
-    def run(self):
-        try:
-            out = subprocess.check_output(['cmake', '--version'])
-        except OSError:
-            raise RuntimeError("CMake must be installed to build the following extensions: " +
-                               ", ".join(e.name for e in self.extensions))
-
-        if platform.system() == "Windows":
-            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
-            if cmake_version < '3.1.0':
-                raise RuntimeError("CMake >= 3.1.0 is required on Windows")
-
-        for ext in self.extensions:
-            self.build_extension(ext)
-
-    def build_extension(self, ext):
-        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-        # required for auto-detection of auxiliary "native" libs
-        if not extdir.endswith(os.path.sep):
-            extdir += os.path.sep
-
-        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
-
-        cfg = 'Debug' if self.debug else 'Release'
-        build_args = ['--config', cfg]
-
-        if platform.system() == "Windows":
-            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
-            if sys.maxsize > 2**32:
-                cmake_args += ['-A', 'x64']
-            build_args += ['--', '/m']
-        else:
-            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
-            build_args += ['--', '-j2']
-
-        env = os.environ.copy()
-        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
-                                                              self.distribution.get_version())
-        if not os.path.exists(self.build_temp):
-            os.makedirs(self.build_temp)
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
 
 setup(
     name='pytomlpp',
@@ -67,7 +15,19 @@ setup(
     author_email='bob.fang.london@gmail.com',
     description='A python wrapper for tomp++',
     long_description='',
-    ext_modules=[CMakeExtension('pytomlpp')],
-    cmdclass=dict(build_ext=CMakeBuild),
+    ext_modules=[
+        Extension(
+            'pytomlpp',
+            ['src/pytomlpp.cpp'],
+            include_dirs=[
+                'src',
+                'third_party',
+                PyBind11Include(),
+            ],
+            extra_compile_args=['-std=c++17'],
+            language='c++',
+        ),
+    ],
+    setup_requires=['pybind11~=2.5'],
     zip_safe=False,
 )


### PR DESCRIPTION
Now simply install with `pip install .`.

This will allow for simple wheel building with `python setup.py bdist_wheel` or `pip wheel . --no-deps`. This is required for PyPI distribution.

Note that the bundled (Git module) PyBind11 isn't used: rather, `pip` gets is during the build process. This means people with only the source-distribution (created by `python setup.py sdist`) can install it without any pre-requisites.