### PR TITLE
Build manylinux wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,52 @@
+services:
+  - docker
 
 dist: trusty
 language: python
-python:
-  - "3.6"
-
-addons:
-  apt:
-    sources:
-      - deadsnakes
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-8
-      - g++-8
-      - cmake
 
 install:
-  - pip install --upgrade setuptools pytest
+  - docker run -e PYABI=$PYABI -v $(pwd):/pytomlpp -w /pytomlpp quay.io/pypa/manylinux2010_x86_64 ci/build-wheel.sh wheels/
+  - ls wheels/
+  - pip install -U pip setuptools wheel
+  - pip install wheels/*.whl
+  - pip install pytest
 
-script:
-  # c++ part, build and run c++ unit tests
-  - export CC=gcc-8
-  - export CXX=g++-8
-  - mkdir -p build
-  - cd build
-  - cmake ..
-  - make -j4
-  - make test
-  - cd ..
+script: pytest -vvra
 
-  # python part
-  - which python
-  - python setup.py build
-  - python setup.py install
-  - pytest -sv
+jobs:
+  include:
+    - python: 2.7
+      env: PYABI=cp27-cp27mu
+      before_script: pip install pathlib2
+    - python: 3.5
+      env: PYABI=cp35-cp35m
+    - python: 3.6
+      env: PYABI=cp36-cp36m
+    - dist: xenial
+      python: 3.7
+      env: PYABI=cp37-cp37m
+    - dist: xenial
+      python: 3.8
+      env: PYABI=cp38-cp38
+    - dist: xenial
+      python: 3.9-dev
+      env: PYABI=cp39-cp39
+
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-8
+            - g++-8
+            - cmake
+      install:
+        - export CC=gcc-8
+        - export CXX=g++-8
+        - mkdir -p build
+        - cd build
+        - cmake ..
+        - make
+      script:
+        - make test
+        - cd ..

--- a/ci/build-wheel.sh
+++ b/ci/build-wheel.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+"/opt/python/${PYABI}/bin/pip" wheel --no-deps -w /tmp/wheels .
+
+for whl in /tmp/wheels/*.whl; do
+    auditwheel show "$whl"
+    auditwheel repair --plat manylinux2010_x86_64 -w ${1} "$whl"
+    rm -v "$whl"
+done

--- a/tests/python-tests/test_api.py
+++ b/tests/python-tests/test_api.py
@@ -1,7 +1,13 @@
+from __future__ import print_function
+
 import pytest
 import glob
 import os
-import pathlib
+
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
 
 import pytomlpp
 
@@ -42,15 +48,15 @@ def test_valid_toml_files(valid_toml_files):
     for t in valid_toml_files:
         if t.stem in VALID_EXCLUDE_FILE:
             continue
-        print(f"parsing {t}")
+        print("parsing", t)
         table = pytomlpp.load(str(t))
         assert type(table) == dict
 
 def test_invalid_toml_files(invalid_toml_files):
     for t in invalid_toml_files:
         if t.stem in INVALID_EXCLUDE_FILE:
-            print(f"skiping {t.stem}")
+            print("skiping", t.stem)
             continue
-        print(f"parsing {t}")
+        print("parsing", t)
         with pytest.raises(RuntimeError):
             pytomlpp.load(str(t))


### PR DESCRIPTION
Build many-linux (2010) wheels in CI

PyPI requires uploaded wheels to be many-linux for distribution.

This PR incorporates #2 (so you might want to merge that in first).

PS: Travis CI is a hot piece of garbage. GitHub actions is so much easier to use.
You might want to squash commits during the merge.