### PR TITLE
Test against expectation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - ls wheels/
   - pip install -U pip setuptools wheel
   - pip install wheels/*.whl
-  - pip install pytest
+  - pip install -r tests/requirements.txt
 
 script: pytest -vvra
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+python-dateutil


### PR DESCRIPTION
Test against the provided expectation in toml-test.

I created a recursive assertion function for comparison rather than using toml-test's Go app as the recursion implementation was going to be needed anyway, and this way we don't have to set up a Go environment, and write a command-line app which handles JSON and TOML from stdin to stdout.