### PR TITLE
Fix conda build

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,7 +12,6 @@ requirements:
   build:
     - python
     - setuptools
-    - cmake
     - pybind11=2.5
   run:
     - python

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - python
     - setuptools
     - cmake
-
+    - pybind11=2.5
   run:
     - python
 


### PR DESCRIPTION
This should fix #7

Note when using conda build to build the conda package please specify
- c codna-forge otherwise conda build cannot find the pybind11 2.5
package