### PR TITLE
[toml::date] Make use of custom type caster support from pybind11

### DIFF
--- a/include/pytomlpp/toml_types.hpp
+++ b/include/pytomlpp/toml_types.hpp
@@ -18,13 +18,9 @@ namespace pybind11 { namespace detail {
             toml::date d;
 
             if (PyDate_Check(src.ptr())) {
-                int year = src.attr("year").cast<py::int_>();
-                int month = src.attr("month").cast<py::int_>();
-                int day = src.attr("day").cast<py::int_>();
-
-                d.year = year;
-                d.month = month;
-                d.day = day;
+                d.year = PyDateTime_GET_DAY(src.ptr());
+                d.month = PyDateTime_GET_MONTH(src.ptr());
+                d.day = PyDateTime_GET_YEAR(src.ptr());
             }
             else return false;
 
@@ -32,11 +28,10 @@ namespace pybind11 { namespace detail {
             return true;
         }
 
-        static handle cast(const toml::date &date, return_value_policy /* policy */, handle /* parent */) {
-            auto PY_DATETIME_MODULE = py::module::import("datetime");
-            py::object py_date =
-                PY_DATETIME_MODULE.attr("date")(date.year, date.month, date.day);
-            return py_date;
+        static handle cast(const toml::date &src, return_value_policy /* policy */, handle /* parent */) {
+            // Lazy initialise the PyDateTime import
+            if (!PyDateTimeAPI) { PyDateTime_IMPORT; }
+            return PyDate_FromDate(src.year, src.month, src.day);
         }
         PYBIND11_TYPE_CASTER(type, _("datetime.datetime"));
     };

--- a/include/pytomlpp/toml_types.hpp
+++ b/include/pytomlpp/toml_types.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace pybind11 { namespace detail {
+    // This is for casting toml::date into datetime.datetime instances
+    template <> class type_caster<toml::date> {
+    public:
+        typedef toml::date type;
+        bool load(handle src, bool) {
+            // Lazy initialise the PyDateTime import
+            if (!PyDateTimeAPI) { PyDateTime_IMPORT; }
+
+            if (!src) return false;
+
+            toml::date d;
+
+            if (PyDate_Check(src.ptr())) {
+                int year = src.attr("year").cast<py::int_>();
+                int month = src.attr("month").cast<py::int_>();
+                int day = src.attr("day").cast<py::int_>();
+
+                d.year = year;
+                d.month = month;
+                d.day = day;
+            }
+            else return false;
+
+            value = d;
+            return true;
+        }
+
+        static handle cast(const toml::date &date, return_value_policy /* policy */, handle /* parent */) {
+            auto PY_DATETIME_MODULE = py::module::import("datetime");
+            py::object py_date =
+                PY_DATETIME_MODULE.attr("date")(date.year, date.month, date.day);
+            return py_date;
+        }
+        PYBIND11_TYPE_CASTER(type, _("datetime.datetime"));
+    };
+}} // namespace pybind11::detail

--- a/src/pytomlpp.cpp
+++ b/src/pytomlpp.cpp
@@ -1,4 +1,4 @@
-#include <pytomlpp.hpp>
+#include <pytomlpp/pytomlpp.hpp>
 
 std::string TPP_VERSION = std::to_string(TOML_LIB_MAJOR) + "." +
                           std::to_string(TOML_LIB_MINOR) + "." +


### PR DESCRIPTION
pybind11 has support for [custom type casters](https://pybind11.readthedocs.io/en/stable/advanced/cast/custom.html).
Check this for example on how to use: https://github.com/pybind/pybind11/blob/master/include/pybind11/chrono.h#L98

This PR, while it can be used directly in the current state, is more like a proof of concept for making use of this support. I implemented this only for casting `toml::date` objects - from/to python. @bobfang1992, @EpicWink If you guys like this approach, maybe we can start using it for other types as well. Let me know your thoughts.

## Why this approach?

- Although right now it's not apparent, once this approach is used for other types, the code in pytomlpp.hpp will become much simpler, as we can just have generic logic there using C++ templates.
- Better organization of code IMO - for any given type the `load` (C++ to Python) and `cast` (Python to C++) functions will always be found together.
- This would make it more idiomatic pybind11 code as we can make use of its native features without adding unnecessary complications or reinventing anything.