### PR TITLE
Add 'dump' and 'load' in Python module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,5 +27,10 @@ keywords = toml, parser, serilization, deserialization, serdes
 setup_requires =
     pybind11~=2.5
 zip_safe = false
+packages = find:
+package_dir = =src
+
+[options.packages.find]
+where = src
 
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
 setup(
     ext_modules=[
         Extension(
-            'pytomlpp',
+            'pytomlpp._impl',
             ['src/pytomlpp.cpp'],
             include_dirs=[
                 'include',

--- a/src/pytomlpp.cpp
+++ b/src/pytomlpp.cpp
@@ -111,7 +111,7 @@ std::string dumps(py::dict object) {
   }
 }
 
-PYBIND11_MODULE(pytomlpp, m) {
+PYBIND11_MODULE(_impl, m) {
   m.doc() = "tomlplusplus python wrapper";
   m.attr("lib_version") = TPP_VERSION;
   m.def("loads", &loads);

--- a/src/pytomlpp/__init__.py
+++ b/src/pytomlpp/__init__.py
@@ -1,0 +1,9 @@
+"""Python wrapper for Toml++."""
+
+__all__ = ["DecodeError", "dumps", "loads", "dump", "load"]
+
+from ._impl import DecodeError
+from ._impl import dumps
+from ._impl import loads
+from ._io import dump
+from ._io import load

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -1,0 +1,27 @@
+"""Python wrapper for Toml++ IO methods."""
+
+from . import _impl
+
+
+def dump(data, fl):
+    """Serialise data to TOML.
+
+    Args:
+        data: data to serialise
+        fl (io.TextIOBase): file-object to write to (supports ``write``)
+    """
+
+    fl.write(_impl.dumps(data))
+
+
+def load(fl):
+    """Deserialise from TOML.
+
+    Args:
+        fl (io.TextIOBase): file-object to read from (supports ``read``)
+
+    Returns:
+        deserialised data
+    """
+
+    return _impl.loads(fl.read())

--- a/tests/python-tests/test_api.py
+++ b/tests/python-tests/test_api.py
@@ -81,20 +81,18 @@ def assert_matches_json(yaml_obj, json_obj):
 
 
 @pytest.mark.parametrize("toml_file", valid_toml_files)
-def test_valid_toml_files(toml_file):
+def test_loads_valid_toml_files(toml_file):
     with open(str(toml_file), "r") as f:
-        toml_file_string = f.read()
-        table = pytomlpp.loads(toml_file_string)
+        table = pytomlpp.load(f)
         table_json = json.loads(toml_file.with_suffix(".json").read_text())
         assert_matches_json(table, table_json)
 
 
 @pytest.mark.parametrize("toml_file", invalid_toml_files)
-def test_invalid_toml_files(toml_file):
+def test_loads_invalid_toml_files(toml_file):
     with pytest.raises(pytomlpp.DecodeError):
         with open(str(toml_file), "r") as f:
-            toml_file_string = f.read()
-            pytomlpp.loads(toml_file_string)
+            pytomlpp.load(f)
 
 
 @pytest.mark.parametrize("toml_file", valid_toml_files)


### PR DESCRIPTION
Add a Python package which provides `dump` and `load`, and exposes `DecodeError`, `dumps` and `loads`.

Closes #17