### PR TITLE
added qtoml to benchmark

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/BurntSushi/toml-test.git
 [submodule "third_party/tomlplusplus"]
 	path = third_party/tomlplusplus
-	url = git@github.com:marzer/tomlplusplus.git
+	url = https://github.com/marzer/tomlplusplus.git

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -1,2 +1,3 @@
 toml
 tomlkit
+qtoml

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,6 +1,7 @@
 import pytomlpp
 import toml
 import tomlkit
+import qtoml
 import timeit
 
 def benchmark(name, func, number=5000):
@@ -14,4 +15,5 @@ with open('data.toml', 'r', encoding='utf-8') as f:
 
 benchmark('pytomlpp', lambda: pytomlpp.loads(test_data))
 benchmark('toml', lambda: toml.loads(test_data))
+benchmark('qtoml', lambda: qtoml.loads(test_data))
 benchmark('tomlkit', lambda: tomlkit.parse(test_data))


### PR DESCRIPTION
```
  pytomlpp:   0.6545989999999993 s
      toml:   4.953170199999999 s
     qtoml:   7.352302399999999 s
   tomlkit:  31.071474500000004 s
```
^_^

I also re-added toml++ submodule with correct https URI, because the previous non-https URI would cause clone failures for some remotes (more info here: https://stackoverflow.com/questions/13509293/git-fatal-could-not-read-from-remote-repository)