### PR TITLE
update toml++ dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 You can try this parser online [here](http://toml-parser.com).
 
-This is an unofficial python wrapper for tomlplusplus (https://marzer.github.io/tomlplusplus/).
+This is an unofficial python wrapper for `toml++` (https://marzer.github.io/tomlplusplus/).
 
 Some points you may want to know before use:
-* Using `tomlplusplus` means that this module is fully compatible with TOML v1.0.0. 
+* Using `toml++` means that this module is fully compatible with TOML [v1.0.0-rc.3](https://toml.io/en/v1.0.0-rc.3). 
 * We convert toml structure to native python data structures (dict/list etc.) when parsing, this is more inline with what `json` module does.
 * The binding is using [pybind11](https://github.com/pybind/pybind11).
 * The project is tested using [toml-test](https://github.com/BurntSushi/toml-test) and [pytest](https://github.com/pytest-dev/pytest).

--- a/include/pytomlpp/pytomlpp.hpp
+++ b/include/pytomlpp/pytomlpp.hpp
@@ -6,6 +6,9 @@
 #define TOML_LARGE_FILES 1
 #define TOML_HEADER_ONLY 0
 #define TOML_UNDEF_MACROS 0 // leaves some toml++'s macros for us to use
+#ifdef __APPLE__
+#define TOML_INT_CHARCONV 0
+#endif
 
 // pytomlpp config
 #ifndef PYTOMLPP_PROFILING


### PR DESCRIPTION
The current HEAD of toml++ (https://github.com/marzer/tomlplusplus/tree/05f8b1f1cce6d353373c9721b15bf7f6268fbd70) reflects what will become v2.3.0 (barring any weird surprises), so I figure I'd push an update for it here too. The version currently integrated into pytomlpp is v2.1.0; Changes since then that might benefit this project:
- fixed a weird, rare edge case where the serializer wouldn't add a line break when printing an array
- fixed some corruption when handling malformed unicode
- fixed some spurious compilation issues on some versions of GCC
- fixed memory leak when handling a failed parse

Also a few minor README tweaks:
- changed "tomlplusplus" to "toml++"
- updated the TOML language version to reflect the specific 1.0.0 release candidate the library supports