### PR TITLE
Build and upload source dists (fixes #47)

### DIFF
--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -63,6 +63,30 @@ jobs:
           name: dist
           path: ./dist
 
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: 3.8
+
+
+      - name: Build sdist
+        run: |
+          ./setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ./dist
+
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -1,8 +1,7 @@
-# Build, test and publish wheels to PyPI
+# Build, test and publish sdist and wheels to PyPI
 # Build and test run on every push
 # Publish runs only on a tag push
-# Note: This does not publish sdist
-name: Wheels
+name: Dists
 
 on: [push, pull_request]
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import platform
 from setuptools import setup, Extension
 


### PR DESCRIPTION
Updates the GitHub Actions: adds a job to build and upload an sdist artifact.

fixes #47 