### PR TITLE
feature: add support for io operations from filenames

### DIFF
--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -3,7 +3,7 @@
 from . import _impl
 
 
-def dump(data, fl, mode="w", encoding="utf-8"):
+def dump(data, fl, mode="w"):
     """Serialise data to TOML.
 
     Args:
@@ -13,11 +13,10 @@ def dump(data, fl, mode="w", encoding="utf-8"):
             or a file name (str, os.Pathlike) that supports ``open``
         mode (str): opening mode. Either "w" or "wt" (text), or "wb" (binary). Defaults to "w".
             Ignored if fl supports ``write``.
-        encoding (str): encoding for binary data. Defaults to "utf-8"
     """
     data = _impl.dumps(data)
     if mode == "wb":
-        data = data.encode(encoding)
+        data = data.encode("utf-8")
     if hasattr(fl, "write"):
         fl.write(data)
         return
@@ -26,7 +25,7 @@ def dump(data, fl, mode="w", encoding="utf-8"):
 
 
 
-def load(fl, mode="r", encoding="utf-8"):
+def load(fl, mode="r"):
     """Deserialise from TOML.
 
     Args:
@@ -35,7 +34,6 @@ def load(fl, mode="r", encoding="utf-8"):
             or a file name (str, os.Pathlike) that supports ``open``
         mode (str):  opening mode. Either "r" or "rt" (text) or "rb" (binary). Defaults to "r".
             Ignored if fl supports ``read``.
-        encoding (str): encoding for binary data. Defaults to "utf-8"
 
     Returns:
         deserialised data
@@ -47,5 +45,5 @@ def load(fl, mode="r", encoding="utf-8"):
         with open(fl, mode=mode) as fh:
             data = fh.read()
     if isinstance(data, bytes):
-        return _impl.loads(data.decode(encoding))
+        return _impl.loads(data.decode("utf-8"))
     return _impl.loads(data)

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -3,25 +3,49 @@
 from . import _impl
 
 
-def dump(data, fl):
+def dump(data, fl, mode="w", encoding="utf-8"):
     """Serialise data to TOML.
 
     Args:
         data: data to serialise
-        fl (io.TextIOBase): file-object to write to (supports ``write``)
+        fl (io.TextIOBase, str or os.Pathlike):
+            file-object to write to (supports ``write``)
+            or a file name (str, os.Pathlike) that supports ``open``
+        mode (str): opening mode. Either "w" or "wt" (text), or "wb" (binary). Defaults to "w".
+            Ignored if fl supports ``write``.
+        encoding (str): encoding for binary data. Defaults to "utf-8"
     """
+    data = _impl.dumps(data)
+    if mode == "wb":
+        data = data.encode(encoding)
+    if hasattr(fl, "write"):
+        fl.write(data)
+        return
+    with open(fl, mode=mode) as fh:
+        fh.write(data)
 
-    fl.write(_impl.dumps(data))
 
 
-def load(fl):
+def load(fl, mode="r", encoding="utf-8"):
     """Deserialise from TOML.
 
     Args:
-        fl (io.TextIOBase): file-object to read from (supports ``read``)
+        fl (io.TextIOBase, str or os.Pathlike):
+            file-object to read from (supports ``read``)
+            or a file name (str, os.Pathlike) that supports ``open``
+        mode (str):  opening mode. Either "r" or "rt" (text) or "rb" (binary). Defaults to "r".
+            Ignored if fl supports ``read``.
+        encoding (str): encoding for binary data. Defaults to "utf-8"
 
     Returns:
         deserialised data
     """
 
-    return _impl.loads(fl.read())
+    if hasattr(fl, "read"):
+        data = fl.read()
+    else:
+        with open(fl, mode=mode) as fh:
+            data = fh.read()
+    if isinstance(data, bytes):
+        return _impl.loads(data.decode(encoding))
+    return _impl.loads(data)

--- a/tests/python-tests/test_api.py
+++ b/tests/python-tests/test_api.py
@@ -87,14 +87,16 @@ def test_loads_valid_toml_files(toml_file):
         table_json = json.loads(toml_file.with_suffix(".json").read_text())
         table_expected = value_from_json(table_json)
         assert table == table_expected
-
+    table = pytomlpp.load(toml_file)
+    assert table == table_expected
 
 @pytest.mark.parametrize("toml_file", invalid_toml_files)
 def test_loads_invalid_toml_files(toml_file):
     with pytest.raises(pytomlpp.DecodeError):
         with open(str(toml_file), "r") as f:
             pytomlpp.load(f)
-
+    with pytest.raises(pytomlpp.DecodeError):
+        pytomlpp.load(toml_file)
 
 @pytest.mark.parametrize("toml_file", valid_toml_files)
 def test_round_trip_for_valid_toml_files(toml_file):
@@ -115,3 +117,9 @@ def test_invalid_encode():
         pass
     with pytest.raises(TypeError):
         pytomlpp.dumps({'a': A()})
+
+@pytest.mark.parametrize("toml_file", valid_toml_files)
+def test_decode_encode_binary(toml_file, tmp_path):
+    data = pytomlpp.load(toml_file)
+    pytomlpp.dump(data, tmp_path / "tmp.toml", mode="wb")
+    assert pytomlpp.load(tmp_path / "tmp.toml", mode="rb") == data

--- a/tests/python-tests/test_api.py
+++ b/tests/python-tests/test_api.py
@@ -96,7 +96,7 @@ def test_loads_invalid_toml_files(toml_file):
         with open(str(toml_file), "r") as f:
             pytomlpp.load(f)
     with pytest.raises(pytomlpp.DecodeError):
-        pytomlpp.load(toml_file)
+        pytomlpp.load(str(toml_file))
 
 @pytest.mark.parametrize("toml_file", valid_toml_files)
 def test_round_trip_for_valid_toml_files(toml_file):
@@ -121,5 +121,5 @@ def test_invalid_encode():
 @pytest.mark.parametrize("toml_file", valid_toml_files)
 def test_decode_encode_binary(toml_file, tmp_path):
     data = pytomlpp.load(toml_file)
-    pytomlpp.dump(data, tmp_path / "tmp.toml", mode="wb")
-    assert pytomlpp.load(tmp_path / "tmp.toml", mode="rb") == data
+    pytomlpp.dump(data, str(tmp_path / "tmp.toml"), mode="wb")
+    assert pytomlpp.load(str(tmp_path / "tmp.toml"), mode="rb") == data


### PR DESCRIPTION
fix #51 
opening as a draft for now, I'll need to add tests

There's room for discussion over the exact implementation for this since no matter how it is handled, it will always add a slight overhead to the existing behaviour, either as an additional conditional check or a try/except.
The latter solution is particularly expensive (performance wise) if an exception is typically raised more than 1% of the time, so I went with the former, which should make both load and dump perform decently in any case, to no significant cost.

A side effect is that in order to achieve this properly, I had to add support to load/dump to and from binary files.