### PR TITLE
Add PyPy to the build matrix and adapt for pypy pybind11 issue

### DIFF
--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -55,10 +55,10 @@ jobs:
 
       - name: Build wheels
         env:
-          # Skip building on Python 2.7 and PyPy
+          # Skip building on Python 2.7
           # Additionally, skip 32-bit Windows for now as MSVC needs seperate setup with different toolchain to do this
           # Refer: https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#windows-and-python-27
-          CIBW_SKIP: cp27-* pp* *-win32 cp35-*
+          CIBW_SKIP: cp27-* *-win32 cp35-*
           CIBW_BEFORE_TEST: pip install -r tests/requirements.txt
           CIBW_TEST_COMMAND: pytest {project}/tests
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64" # build on M1 chip

--- a/src/encoding_decoding.cpp
+++ b/src/encoding_decoding.cpp
@@ -74,7 +74,14 @@ toml::array py_list_to_toml_array(const py::list &list) {
       arr.push_back(time_value);
     } else {
       std::stringstream ss;
+#ifdef PYPY_VERSION
+      // see https://github.com/conda-forge/pytomlpp-feedstock/pull/1#issuecomment-972738986
+      // and https://github.com/pybind/pybind11/issues/3408#issuecomment-972752210
+      ss << "not a valid type for conversion " << std::endl;
+#else
       ss << "not a valid type for conversion " << it << std::endl;
+#endif
+      std::cout << "uhoh, bad type" << std::endl;
       throw py::type_error(ss.str());
     }
   }

--- a/src/encoding_decoding.cpp
+++ b/src/encoding_decoding.cpp
@@ -75,13 +75,14 @@ toml::array py_list_to_toml_array(const py::list &list) {
     } else {
       std::stringstream ss;
 #ifdef PYPY_VERSION
-      // see https://github.com/conda-forge/pytomlpp-feedstock/pull/1#issuecomment-972738986
-      // and https://github.com/pybind/pybind11/issues/3408#issuecomment-972752210
+      // see 
+      // https://github.com/conda-forge/pytomlpp-feedstock/pull/1#issuecomment-972738986
+      // and 
+      // https://github.com/pybind/pybind11/issues/3408#issuecomment-972752210
       ss << "not a valid type for conversion " << std::endl;
 #else
       ss << "not a valid type for conversion " << it << std::endl;
 #endif
-      std::cout << "uhoh, bad type" << std::endl;
       throw py::type_error(ss.str());
     }
   }

--- a/src/encoding_decoding.cpp
+++ b/src/encoding_decoding.cpp
@@ -75,9 +75,9 @@ toml::array py_list_to_toml_array(const py::list &list) {
     } else {
       std::stringstream ss;
 #ifdef PYPY_VERSION
-      // see 
+      // see
       // https://github.com/conda-forge/pytomlpp-feedstock/pull/1#issuecomment-972738986
-      // and 
+      // and
       // https://github.com/pybind/pybind11/issues/3408#issuecomment-972752210
       ss << "not a valid type for conversion " << std::endl;
 #else

--- a/tests/python-tests/test_api.py
+++ b/tests/python-tests/test_api.py
@@ -117,6 +117,8 @@ def test_invalid_encode():
         pass
     with pytest.raises(TypeError):
         pytomlpp.dumps({'a': A()})
+    with pytest.raises(TypeError):
+        pytomlpp.dumps({'a': [A()]})
 
 @pytest.mark.parametrize("toml_file", valid_toml_files)
 def test_decode_encode_binary(toml_file, tmp_path):


### PR DESCRIPTION
This is a result of the pypy failure in the conda feedstock. The problem with pybind11 is tracked here https://github.com/pybind/pybind11/issues/3408#issuecomment-972752210