### PR TITLE
benchmark script improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,18 @@ There are some existing python TOML parsers on the market but from my experience
 
 ```
 Parsing data.toml 5000 times:
-  pytomlpp:    0.846 s
-     tomli:    3.317 s (3.9x slower)
-      toml:    5.697 s (6.7x slower)
-     qtoml:    8.473 s (10.0x slower)
-   tomlkit:   43.250 s (51.0x slower)
+  pytomlpp:   0.694 s
+     rtoml:   0.871 s ( 1.25x)
+     tomli:   2.625 s ( 3.78x)
+      toml:   5.642 s ( 8.12x)
+     qtoml:   7.760 s (11.17x)
+   tomlkit:  32.708 s (47.09x)
 ```
 Test it for yourself using [the benchmark script](benchmark/run.py).
 
 # Installing
 
-We recommand you to use `pip` to install this package:
+We recommend you to use `pip` to install this package:
 ```sh
 pip install pytomlpp
 ```

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -3,3 +3,4 @@ toml
 tomlkit
 qtoml
 tomli
+rtoml


### PR DESCRIPTION
This is the benchmark-specific stuff that was in my other PR, #62. Figured I'd pull it out of that so it can be merged in separately. 

Note the timings are from the current version of toml++ being used in `master`, not the new one, so they'll get better once I finish v3 :)

- added `rtoml`
- sorted results in ascending order of time taken
- guard against missing imports (e.g. if a package is not available on some platform)
- updated timings in README