### PR TITLE
fix wrong kwarg that fails on pytest 7

### DIFF
--- a/tests/python-tests/test_api.py
+++ b/tests/python-tests/test_api.py
@@ -30,7 +30,7 @@ _marks = {
     for s in TOML_0_4_SPECIFIC
 }
 _valid_marks = {
-    s: (pytest.mark.skip(reson="Skipping for these tests for now"))
+    s: (pytest.mark.skip(reason="Skipping for these tests for now"))
     for s in TOML_TESTS_SKIP
 }
 valid_toml_files = [


### PR DESCRIPTION
Upstreaming patch from https://github.com/conda-forge/pytomlpp-feedstock/pull/10

Fixes #66