### PR TITLE
update toml++ to v3.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "third_party/tomlplusplus"]
 	path = third_party/tomlplusplus
 	url = https://github.com/marzer/tomlplusplus.git
+	shallow = true

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Out[6]: '"你好" = "world"'
 There are some existing python TOML parsers on the market but from my experience they are implemented purely in python which is a bit slow.
 
 ```
-Parsing data.toml 5000 times:
-  pytomlpp:   0.694 s
-     rtoml:   0.871 s ( 1.25x)
-     tomli:   2.625 s ( 3.78x)
-      toml:   5.642 s ( 8.12x)
-     qtoml:   7.760 s (11.17x)
-   tomlkit:  32.708 s (47.09x)
+Parsing data.toml 1000 times:
+  pytomlpp:   0.914 s
+     rtoml:   1.148 s ( 1.25x)
+     tomli:   4.850 s ( 5.30x)
+     qtoml:  11.882 s (12.99x)
+   tomlkit:  72.140 s (78.89x)
+      toml: Parsing failed. Likely not TOML 1.0.0-compliant.
 ```
 Test it for yourself using [the benchmark script](benchmark/run.py).
 

--- a/benchmark/data.toml
+++ b/benchmark/data.toml
@@ -1,94 +1,578 @@
-addition-used = false
-afraid-boiling-draconian = 1916-12-15T11:26:42+11:26
-boiling-whip = 12:23:17.000000129
-charming = 16771
-close-unbecoming = 14:49:02
-contain-terrible-neck = 1928-11-07T06:30:56
-creature = 0.4857
-crowded-profuse-capable = 1932-05-28
-deserted-cross-creature = 1931-12-26T04:31:04
-deserted-heavy = [ 2014-02-08, 1984-03-16, 1910-08-05 ]
-fabulous = 0.3388
-ghost-birds-legal = 1989-09-02
-grandfather-weary = 10216
-haircut-dreary-broken = 'unadvised rejoice lewd crime grandfather rice imperfect'
-harm-snow = 0.6724
-leather-aromatic-rabbit = false
-license-harm = 1987-08-15T15:30:51+03:24
-naughty-self-close = 1916-09-21T01:53:27-02:59
-neck = 29653
-neck-crime-wistful = 1998-12-07
-rest-afraid = [
-    1912-06-23T07:00:07-07:46,
-    1910-11-17T13:10:34,
-    2014-08-03T04:37:12-06:36,
-    1966-11-22T18:08:23+06:10,
-    1985-03-01T08:11:38,
-    1976-09-04T20:46:46+00:29,
-    1964-05-18T20:13:27-01:25,
-    1961-10-14T11:03:51.000011555+06:23,
-    2005-07-13T02:57:15-01:46,
-    2007-02-01T17:09:54-08:45,
-    1952-03-06T09:15:04+01:44,
-    1962-12-25T23:00:11+04:28
-]
-rotten-best = 0.0325
-run-curious = true
-run-meaty = 04:40:20.000003312
-scintillating-cream = 0.2604
-sisters-playground = 'week spiritual pause insidious uptight'
-spiritual-borrow-messy = 16:49:32
-surprise-jail-babies = 2008-01-01
-title-unbiased = 1958-10-08
-unbecoming-scene-lewd = true
-worried-spicy = 23:03:54
+boiling-morning = 947
+capable-adhesive = 09:20:44
+cure = 0.4747 # broken
+deserted = 0.3939
+finger-surprise = true
+flimsy-hook = { wistful-vengeful-complex = [ 2012-06-01T14:49:11+09:41 ] } # experience
+naughty = 1928-08-08T22:22:07+06:02
+remarkable-umbrella-flagrant = 1910-09-26
+silky-ski-threatening = 'bore regret' # reject
+soap-decisive = ''
+want = 0.4848
 
-[contain]
-ghost = 0.2471
-tank-lackadaisical = 1945-02-18T22:22:27+01:41
+[[babies-lewd-relation.playground-snow-rotten]]
+addition-cobweb = 0.8157
+bore = 'acceptable stale adhesive stale curtain deserted'
+close-hard-to-find = {} # finicky righteous
+contain-train = { ball-license-babies = 22:44:01, string-cross = 0.4102, used-rest = 2014-09-05T17:02:28 }
+flat-cheerful = {}
+license-gleaming-laughable = 2009-06-03
+rich-title-fuel = 'close tacky stale bake'
 
-    [contain.righteous-imperfect-remarkable]
-    ticket = 0.2412
-    voyage = 'prefer silky night draconian three dreary decisive'
-    wilderness-draconian = 04:58:17
+    [babies-lewd-relation.playground-snow-rotten.aromatic-overjoyed]
+    whip-addition = {} # insidious
 
-        [contain.righteous-imperfect-remarkable.deeply-night-gold]
-        legal = 1981-07-04
-        righteous = [ false, true, false, false, true ]
-        wilderness = 1900-12-24
+    [babies-lewd-relation.playground-snow-rotten.morning-adorable-gleaming] # deeply spicy
+    legal-imperfect-worried = 06:23:39
+    modern = 1968-01-21
+    skip-sprout-zealous = ''
+    step-history = {}
 
-[crime]
-boiling-excuse-incandescent = 31173
-flat-rejoice = 0.8682
-furtive = 6866
-heavy-memory = 5545
-lackadaisical-terrible-overjoyed = [ 'harm acceptable naughty pause', 'page anxious threatening lewd' ]
-reject-aromatic = [ false, true, true, true, false, true ]
-reject-naughty = 11229
-scintillating-bake-harm = 0.8258
+[[babies-lewd-relation.playground-snow-rotten]]
+draconian-addition-threatening = 'behave experience impossible' # high-pitched unbecoming
+stingy-equable-clean = 1975-03-17 # protective
+versed-bake = 505
 
-[license-bat]
-adorable-blind-string = 1961-08-14
-bat = 1939-10-28
-blind-wilderness = 2004-07-14
+[[babies-lewd-relation.playground-snow-rotten]]
+night = 0.778
+prefer-torpid-ski = [ 0.6483, false, 1982-01-23T16:10:13-01:55 ]
+soap = { fix = 2019-07-24T07:38:55+01:19, umbrella = 1947-02-13T18:02:46 }
+soap-blind = 1964-05-23 # run prefer
+used-ancient-delightful = false
+worried-string = [ [ 'borrow unbecoming geese' ] ]
 
-[rapid]
-borrow = true
-jail-weary-furtive = 'room'
-protective-sulky = 4737
-room-decisive-unbiased = 1998-11-01T12:23:58
-soap = 1985-05-06
-sprout-rich = 0.6026
+# title tacky dull draconian lewd dreary
+# deeply anxious surprise torpid unite relation kindhearted
+# skip dull room train experience
+# borrow satisfy scintillating neck impossible aromatic high-pitched
+# week respect ghost capable
+# satisfy deserted capable rabbit string threatening
 
-    [rapid.clean-leather]
-    blood-snow-mark = true
-    equable = 0.2923
-    fabulous = 1979-07-24T00:53:39+06:22
-    glorious-threatening = true
-    lewd-dull = 02:40:53.000027288
+    [babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train] # best
+    hard-to-find = 'terrible'
+    picture = 'ball history'
+    step-decisive = 02:54:51
 
-[run-overjoyed]
-creature-cheerful = 11071
-respect-history-anxious = 0.4637
-vessel = 'curious'
+        [babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.crowded-protective] # leather unbecoming
+        blind = 1905-03-22
+        clean-wilderness-leather = 09:45:08 # scatter
+        impossible-ski = 536 # sprout
+        license = [ 1952-02-22T17:07:05.000005978+10:25, 1996-07-04T14:01:50 ] # stale stingy
+        surprise-fuel = { borrow-kindhearted = 1986-03-23T20:44:26+07:51 } # playground
 
+        [babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.playground-bore] # hook flagrant
+        addition-scatter-tacky = 02:17:38
+        close = { crown-respect-prefer = 03:27:27 }
+        incandescent = 10:04:01
+        march-dreary-room = true
+        mark-influence = true
+        picture-squirrel-surprise = 901
+        scene-rest-capable = [ 'torpid light attempt', 12:09:26.000008459 ] # addition
+        unbecoming-decisive = { bat = [ 1913-12-15T13:13:49, '' ], march-experience-tank = 1911-12-04T18:29:34-04:06, relation-remarkable = false }
+        whip-actually = [ [], [ 1996-05-28 ] ] # umbrella imperfect
+
+# stale voyage run popcorn threatening bore
+# fabulous respect chubby ancient wistful creature
+# surprise prefer dull curious whip
+# used blue-eyed furtive torpid selfish chubby nondescript
+# curious complex geese jail
+
+            [[babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.playground-bore.influence-scintillating-vengeful]]
+            babies-surprise-stingy = { surprise-contain-weary = 14:56:22 }
+            borrow = 1996-06-04 # ancient
+            fuel-miss-rich = [ 0.1081, 0.8454 ]
+            grandfather = false
+            haircut-versed-innocent = { boiling-innocent-blue-eyed = { blood-capable = 853, overjoyed-kindhearted = 0.2161 }, regret-ignore = 1905-02-06 }
+            step-insidious-adhesive = [ 1950-01-06, {}, false ]
+            unbiased = 784 # unite title
+            uptight-itch-curtain = false
+
+            [[babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.playground-bore.influence-scintillating-vengeful]] # title relation
+            deadpan = 1958-06-22T18:31:51+10:16
+            fix = 0.3198 # heavy sulky
+            page-stingy-selfish = 1930-06-19T02:38:48.000016194
+            picture-lackadaisical = false # ghost
+            tank-contain = 'memory consist helpless'
+            versed-leather-ghost = 'influence wistful flat'
+            wretched-march = 'place enthusiastic decisive'
+
+        [babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.vengeful-worried]
+        capable-bake-room = 1988-10-22 # actually unite
+        cycle = false
+        high-pitched-vengeful = 0.0822
+        tank-license = 1953-02-12T14:43:36.00003003-00:35
+        threatening = 03:43:23
+
+# vessel remarkable pumped step draconian scary
+# pear selfish birds regret license stingy playground
+# pear babies geese rice ignore
+# run reject rapid reject
+
+            [babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.vengeful-worried.ghost-heavy] # respect
+            advise-bore = true
+            broken-lewd = true
+            scatter = 6 # neck
+            scintillating-regret-unadvised = 1936-07-25T17:22:32-05:14
+            versed-miss = 0.9028
+            weary = []
+
+            [babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.vengeful-worried.pumped-wistful]
+            contain-modern = 1923-09-23T01:22:09-02:20
+            curious-silky-borrow = 1959-11-06T04:37:54-02:58 # rotten
+            hilarious = 1903-12-02
+            insidious-tacky = 'harm spiritual laughable cycle influence messy enthusiastic'
+            wall-sprout-scary = 10:44:31
+            week-dull = {} # leather enthusiastic
+
+            [babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.vengeful-worried.unadvised-gold-unadvised]
+            attempt = 1957-09-11
+            flagrant-miss-tent = 0.8814
+            legal-versed-sprout = false
+
+            [[babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.vengeful-worried.scene-naughty-spare]]
+            deserted-hilarious = {}
+            scatter-attempt = 'blind pear'
+
+        [[babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.blue-eyed]] # blue-eyed run
+        borrow-run-mark = 0.5925
+        complex-profuse = 1907-02-26T23:54:24.000028223+10:35
+        crown-ticket = 'babies helpless'
+        dull = 1942-11-26
+        furtive = 816
+        respect = 20:07:11
+        string-cheerful-satisfy = 10:15:06
+        unbecoming-furtive-unite = 2008-09-02T16:34:04+08:40
+
+            [[babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.blue-eyed.naughty-laughable-actually]]
+            legal-attempt-light = 1934-09-24T20:24:29-10:18
+            remarkable = 2020-10-02T19:53:38
+            three-cure-innocent = [ 0.2179 ]
+            versed-attempt = 1917-11-11
+            week-draconian = 797
+
+            [[babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.blue-eyed.naughty-laughable-actually]] # skip
+            fabulous-ignore = 2005-08-06
+            messy = 242 # gusty worried
+
+        [[babies-lewd-relation.playground-snow-rotten.protective-kindhearted-train.blue-eyed]]
+        fabulous = 0.8882
+        fix = 1928-07-04T15:46:25-06:46
+        rabbit-gold = 0.8035
+        royal = 1989-09-26T07:06:21-08:43 # complex borrow
+        terrible-capable-crowded = {}
+        unbecoming = 201
+        view = 12:19:31 # ignore
+        wilderness-tent-week = [ 384 ]
+
+    [babies-lewd-relation.playground-snow-rotten.whip-enthusiastic-ignore]
+    afraid = 2010-08-09
+    ball = 17:51:13 # vengeful
+    blind-heavy = 'cheerful profuse innocent dreary' # legal hard-to-find
+    deserted-itch = 1984-03-02
+    skip-protective = 22:27:14
+    spare-view-hook = { flimsy-partner-fuel = 727, memory-blue-eyed = 0.9457 }
+
+        [[babies-lewd-relation.playground-snow-rotten.whip-enthusiastic-ignore.skip-bake-incandescent]]
+
+            [babies-lewd-relation.playground-snow-rotten.whip-enthusiastic-ignore.skip-bake-incandescent.influence-bat-actually]
+            broken-surprise = 21:24:24.000002983
+            leather-taboo-dull = { deeply = [ 813, 07:48:43.000014695 ], run-bake = 'march used scatter attempt close chubby innocent', tacky-party = 2005-02-06 } # cross
+            productive = { page = 361, three-tank-wistful = [ 2016-07-20, 13:18:08, 'light curtain morning rabbit harm sisters high-pitched' ] }
+            terrible-partner-room = 1915-06-07
+            train = 0.4414
+
+# innocent string contain regret crime decisive wall
+# spiritual naughty tacky stale attempt
+# deadpan cure experience royal ancient cure voyage
+# remarkable whip ski best haircut
+
+            [babies-lewd-relation.playground-snow-rotten.whip-enthusiastic-ignore.skip-bake-incandescent.rice-skip-used]
+            bake-pear-train = 813 # vengeful
+            clean-ancient = 2012-11-13
+            complex = { naughty-deadpan-actually = 06:52:59, room-boiling = 0.1027 }
+            haircut = true # tacky prefer
+            rejoice-uptight = 0.6769
+            spicy = true
+            surprise = false # deadpan worried
+            threatening = 1978-02-04
+            title-acceptable = 1956-02-22
+
+            [[babies-lewd-relation.playground-snow-rotten.whip-enthusiastic-ignore.skip-bake-incandescent.selfish]] # license incandescent
+            acceptable-decisive = 'skip flat gold influence morning unbiased'
+            deadpan = 0.7201 # finicky
+            dull-borrow = 1900-12-08 # dreary capable
+            hilarious-vengeful = {} # furtive
+            jail-consist-scatter = 0.1787
+            scene-vessel-complex = 1971-02-15
+            taboo-dull = 0.1922
+            taboo-ignore = 2019-04-22 # deadpan
+            unadvised-scene = 03:16:52
+
+        [[babies-lewd-relation.playground-snow-rotten.whip-enthusiastic-ignore.skip-bake-incandescent]]
+        contain = false
+        legal-hilarious = []
+        rejoice = [ 1979-08-21T05:58:09-06:39, 'creature memory' ]
+        wall-flagrant-self = 0.4976
+
+    [[babies-lewd-relation.playground-snow-rotten.wall]] # protective
+    capable = [] # wilderness snow
+    clean = 1963-02-17
+    complex-umbrella = { familiar-innocent-consist = 175, stale = 07:03:20.00002881 }
+    creature-gleaming-sisters = 1984-05-19 # gleaming
+    crowded-squirrel = 1974-10-07
+    enthusiastic-three-tent = { capable-crowded = 1931-03-05T09:28:53-07:42, flat-broken-clean = {} }
+    light-snow = false # silky
+    wilderness-light-curious = 989 # actually
+
+        [babies-lewd-relation.playground-snow-rotten.wall.threatening]
+        chubby-overjoyed = 0.7252 # cheerful
+        cream-addition = 0.8832
+        familiar-high-pitched = 2013-11-10
+        laughable-geese-borrow = {}
+        overjoyed-bake = 1919-07-25
+        respect-umbrella = 1947-09-18 # charming
+        scene-rapid = false
+        surprise-delightful-stingy = { creature-pause = 0.9945, room-advise = '', tent-snow = '' } # rabbit
+
+    [[babies-lewd-relation.playground-snow-rotten.wall]]
+    crown-unbiased = 06:10:11 # jail
+    impossible-flimsy = 1992-09-13T01:39:28.000005689-05:33
+    rejoice = [ false ]
+    ski-ball-run = 'finicky haircut vessel spicy'
+    tacky = 9 # ignore
+    vengeful-rabbit = true # lackadaisical fix
+
+# jail excuse enthusiastic cream complex
+# train satisfy fix broken
+# threatening boiling attempt train delightful cheerful vengeful
+# rich actually fabulous contain deadpan harm curious
+# fabulous scene furtive acceptable blood
+# meaty used curious mark surprise curtain hard-to-find
+
+        [babies-lewd-relation.playground-snow-rotten.wall.terrible]
+        aromatic = 1937-12-11T00:23:12 # addition whip
+        glorious-wretched = { tank-adorable-gold = false, wilderness-cure-history = [ 1957-11-25T20:10:27.000016213+04:26, 2008-02-17, 20:40:09 ] }
+        squirrel-flagrant-boiling = { skip-room = { nondescript-morning-excuse = 1904-05-01T16:47:38+10:26 } }
+        surprise = 0.3398
+        worried = 'wretched experience ancient'
+
+# week hilarious miss sprout
+
+            [babies-lewd-relation.playground-snow-rotten.wall.terrible.anxious] # crown tacky
+            fabulous-impossible = false # spare
+            fuel = 1908-09-09 # stale charming
+            license-ticket = [] # regret rejoice
+            sprout-mark-selfish = { page = 23:36:46.0000114, weary-deserted-history = [ true ] }
+            voyage = { meaty-helpless = 1980-04-20 }
+
+# bore babies influence overjoyed advise light
+# righteous remarkable leather stingy partner actually advise
+# scary familiar deadpan gleaming adhesive broken experience
+# mark unbiased popcorn squirrel close capable
+# scintillating ski productive unbecoming haircut
+# tank attempt scene rabbit high-pitched sprout
+# gusty attempt flimsy ski pear terrible rice
+
+            [babies-lewd-relation.playground-snow-rotten.wall.terrible.boiling] # flimsy glorious
+            charming-royal = 04:14:31.000005876
+            curtain = 2005-08-17T06:45:00 # equable
+            draconian-clean-enthusiastic = 'history'
+            fix = 19:53:23
+            influence-week-reject = 581 # spiritual bore
+            self-protective = 2004-01-19T01:00:26.000016471+00:16
+            step-overjoyed-history = [ 'curious satisfy', [ 'overjoyed bat advise grandfather', 0.5762 ], 1947-06-28T09:03:40-08:39 ]
+
+            [babies-lewd-relation.playground-snow-rotten.wall.terrible.laughable-crime] # babies
+            umbrella = 1938-06-10
+
+# furtive actually cross creature
+# rest ghost mark selfish deadpan wistful torpid
+
+            [[babies-lewd-relation.playground-snow-rotten.wall.terrible.versed-overjoyed]] # hilarious
+            blind-familiar = 73 # gold respect
+            clean-train = { borrow-flagrant = 0.6438, unbecoming-fabulous-cheerful = false } # week
+            flimsy-pumped-umbrella = { string-boiling = { insidious-sisters = 10:33:25 }, weary = { behave-rejoice-threatening = 0.9151, protective-grandfather = 'haircut', view-regret-partner = false } } # unadvised finger
+            modern = 0.1885
+            place-cross = [ {} ]
+            tank = false
+            terrible-enthusiastic = 'hook' # train
+            threatening-best = 1908-09-20 # ticket
+            unbecoming-high-pitched = 09:47:03 # selfish productive
+
+            [[babies-lewd-relation.playground-snow-rotten.wall.terrible.versed-overjoyed]]
+            anxious = [] # equable
+            clean-satisfy = [ 0.8894, 153 ]
+            scene = 17:37:43 # clean ancient
+
+# voyage wall deserted furtive rest aromatic
+# cross flat cure productive cheerful
+
+            [[babies-lewd-relation.playground-snow-rotten.wall.terrible.versed-overjoyed]] # charming laughable
+            ball-deserted = 'voyage' # crown
+            deadpan-prefer-deeply = 104
+            fabulous-influence-wall = 0.0613
+            ignore = 1982-07-11
+            modern = { helpless-imperfect-leather = [ 'unbiased familiar place', 06:33:07.00002173, 0.5918 ], worried-crowded = false } # helpless want
+            party-complex-laughable = 11:39:52 # rice light
+            rich-three = 1929-11-07T03:53:23
+            royal-behave-babies = { fabulous-mark = [ 659, true ], unbecoming-messy = [] } # rich broken
+            spare = [ 1935-09-28T14:49:51-02:02 ]
+
+    [[babies-lewd-relation.playground-snow-rotten.wall]] # threatening
+    contain = [ 1918-09-06 ]
+    haircut-selfish-gusty = 976 # spicy stale
+    rotten = [ true, 'afraid overjoyed kindhearted threatening jail deadpan cure' ]
+    scene-charming-delightful = 'rice crown room'
+    scintillating-umbrella-crowded = true
+    selfish = 1986-11-28
+    stale = 0.3828
+    title-equable-partner = 508 # zealous
+
+[[terrible]]
+boiling-anxious-heavy = 1975-02-23
+
+    [terrible.capable-tent]
+    behave-ski-geese = true
+    borrow = true
+    capable-blue-eyed = 0.96
+    delightful-fabulous = 14:05:34
+    glorious = [ # finger spicy
+        { best = 0.3935, cycle-acceptable = 05:55:20, spiritual-zealous-high-pitched = 'borrow actually taboo unadvised deadpan' },
+        false
+    ]
+    hilarious = [ 0.0929 ]
+    spiritual-tank-sprout = 1969-10-20
+    week = false
+    wretched-step = { close-reject-excuse = 'taboo popcorn party', finger-soap-best = 0.5234 }
+
+        [terrible.capable-tent.contain-spiritual-squirrel]
+        delightful-torpid-three = 'rejoice'
+        haircut-regret-curious = 0.7427
+        morning-babies = 'hilarious voyage royal complex crown complex'
+        rest-impossible-borrow = '' # deserted behave
+        scatter-rest-impossible = { rich-close-actually = 878, vengeful = 0.2007 } # tank run
+        tacky-neck-cheerful = [ {}, [] ]
+
+        [terrible.capable-tent.week-week-zealous]
+        bat-zealous = 'morning lewd consist familiar morning crowded laughable' # uptight ski
+        delightful-tank = 1948-04-17 # charming
+        excuse = 1939-09-20T05:39:20.000019588+07:59
+        gold = 1901-05-16T23:53:21-05:25
+        royal = '' # remarkable
+        self = { train-birds-stingy = 'insidious scene gold', vessel = 0.5759 }
+        soap = { dull-history = false, scary = false }
+        taboo-ancient-itch = { gusty-snow-pear = { protective-scatter-high-pitched = 1996-11-03 }, rejoice-ignore-finger = 1918-11-22T19:37:38, squirrel-high-pitched-nondescript = 1995-07-17T04:54:13 }
+        umbrella-partner = []
+
+        [terrible.capable-tent.wilderness-aromatic]
+        attempt-night = 23:28:50 # borrow
+        cross-spare-hook = [ 1919-06-28T19:24:17-04:44, 08:23:11 ]
+        pear-helpless-profuse = true
+        productive-whip = 349
+        rapid-scary = 23:34:33
+        rotten-wistful = 1944-11-27
+        threatening = false # chubby
+        view-afraid = false
+
+# neck draconian innocent innocent unbecoming advise
+# voyage aromatic train gold broken harm memory
+# fuel broken string unbecoming
+# party party stale ski advise lewd
+
+            [terrible.capable-tent.wilderness-aromatic.tank]
+            cheerful-zealous-experience = 41
+            memory = 890 # deadpan
+            naughty = 1991-07-27T16:21:58+02:12
+            sisters = true # royal
+            tent-threatening-threatening = 0.1835
+
+# attempt rabbit boiling train laughable wistful
+# soap excuse spare neck babies unbiased fix
+# legal unbecoming flagrant rest excuse uptight royal
+
+                [[terrible.capable-tent.wilderness-aromatic.tank.terrible]]
+                birds = [ true, 12:01:59, 1993-12-06 ]
+                scintillating-vengeful = 'snow party train unbiased innocent'
+                sulky = 'popcorn'
+
+                [[terrible.capable-tent.wilderness-aromatic.tank.terrible]]
+                wistful-innocent-morning = 482
+
+                [[terrible.capable-tent.wilderness-aromatic.tank.terrible]]
+                adorable = [ false, [ 1986-08-22T06:58:04, 211 ] ]
+                crowded = [ 06:00:22, 15:39:55 ]
+                dreary-decisive = 1937-08-23
+                familiar-taboo-unite = false
+                glorious = true # room messy
+                license-anxious-prefer = ''
+                pumped = 2010-02-06T18:30:43-07:27
+                royal = 1949-03-01T15:27:36
+
+            [[terrible.capable-tent.wilderness-aromatic.birds]]
+            hook-dull-familiar = 2020-05-09T10:12:18-00:21
+            imperfect = false
+            pear = 'vengeful worried self close worried'
+
+            [[terrible.capable-tent.wilderness-aromatic.birds]]
+            bore-unite-flimsy = { finicky-legal-view = [ 749 ] }
+            grandfather-unbiased = 'modern delightful actually cream' # versed
+            haircut-soap = 2004-05-01T21:12:27+01:34
+            innocent-crime-unbiased = 'three flimsy'
+            lewd-adorable = 05:25:31 # best fuel
+            neck = 17:07:42
+            rabbit-versed = 11:23:17.000021208
+            step-overjoyed-anxious = 0.2862
+            weary-creature-itch = [ 2012-05-13T05:12:55+10:38, 1983-01-06T06:23:03-04:47 ] # skip ticket
+
+            [[terrible.capable-tent.wilderness-aromatic.birds]]
+            hook-rest-impossible = [ 21:02:47.000007906, 0.9952, [ 1977-05-22, true, true ] ]
+            sisters-rotten = 276
+
+                [terrible.capable-tent.wilderness-aromatic.birds.naughty-blind]
+                bake-scatter-cross = [
+                    234,
+                    { attempt-selfish-ghost = 08:43:45, draconian-ski-scintillating = 1911-03-24T12:01:06-01:20, dreary = 266 },
+                    'innocent broken equable adhesive spiritual title respect'
+                ] # hard-to-find protective
+                ticket-enthusiastic-delightful = [ 428, 12:49:26, [ 07:10:40, 'neck unadvised finicky stale rest', true ] ]
+
+                [terrible.capable-tent.wilderness-aromatic.birds.popcorn-cross-unbecoming]
+                capable-best = [ { fabulous = 0.0328 }, 1959-07-11T18:30:11-10:19, [ false, 1943-02-01T14:46:20+04:32 ] ]
+                contain = { harm-babies-actually = 1927-05-26, lackadaisical-cobweb-ticket = { license-stale = true }, zealous = 14:34:49 }
+                dreary-rejoice = false
+                ignore-cobweb = true
+                jail = false
+                legal = {}
+
+                [terrible.capable-tent.wilderness-aromatic.birds.rotten]
+                innocent = 2012-07-13
+                stingy = 12:22:46
+                wilderness = true
+
+        [[terrible.capable-tent.taboo-snow-fix]]
+        consist = 0.5019
+        deadpan-title-equable = []
+        enthusiastic = 'jail step deserted' # neck
+        high-pitched-ski-jail = {}
+        lackadaisical-page = 2011-04-21
+        leather-grandfather-lackadaisical = 'kindhearted kindhearted rich babies' # umbrella
+        relation-high-pitched = 1995-11-05 # blue-eyed cream
+        self-deeply-crown = 0.6038 # pumped relation
+        spare-behave-royal = 1955-01-15T04:19:40.000024836-03:27
+
+    [terrible.history-wistful-insidious]
+    deadpan-run = 1961-12-04T21:19:22
+    impossible-itch-hilarious = []
+    wall-silky-zealous = false
+
+        [terrible.history-wistful-insidious.broken-bore]
+        decisive-spicy = 01:43:10
+        finger-deeply = 03:52:20
+        jail = [ 'week title curtain week snow' ]
+        jail-borrow = true # flimsy
+        kindhearted-tent-harm = 1979-06-03
+        playground-unbecoming = 0.3341
+        used-unbecoming-cobweb = 0.7474
+
+            [terrible.history-wistful-insidious.broken-bore.draconian.silky] # afraid unbiased
+            bat-vessel-enthusiastic = 1988-05-20T20:51:44+00:23
+            decisive-close-rest = 1979-07-27T21:30:02-07:46
+            messy = 0.2638 # excuse
+            stingy-self-rejoice = 0.0179
+            tacky-mark = 'wilderness furtive incandescent delightful close rotten' # best
+            vessel = 2006-06-28T20:54:53 # umbrella
+
+        [[terrible.history-wistful-insidious.cobweb-finicky]]
+        attempt-selfish-skip = []
+        ball-ball = 0.1378 # aromatic best
+        blind-curtain = 06:26:13
+        fuel-fix-geese = 1918-06-21T14:07:38
+        high-pitched-three = 16:58:45
+        innocent-rabbit = 'train'
+        miss = 'glorious chubby cobweb skip dreary scene ball'
+        morning = 'unbiased ticket deeply anxious skip terrible dreary'
+        playground = 'sisters run' # scene cycle
+
+        [[terrible.history-wistful-insidious.cobweb-finicky]]
+        fabulous = [ 'flimsy spare tent rejoice curtain mark', true ]
+        rabbit = {}
+        ticket = false
+
+# unadvised sulky acceptable righteous broken profuse terrible
+# ancient crown gleaming wistful ball rest
+# picture deadpan mark flimsy scatter decisive
+# close memory skip bat tent haircut
+# run attempt morning vengeful delightful legal itch
+
+    [terrible.productive]
+    itch = ''
+
+[[terrible]]
+babies-sisters = 62
+boiling = { deserted = 'adorable', lackadaisical-wilderness = 671 }
+decisive-itch = 1943-07-24 # cross rest
+ignore-best = [ 1916-02-18T15:56:45+02:04 ]
+overjoyed = 17:49:57
+place-familiar = true
+sisters = []
+used-rotten = 1985-08-10T07:39:42+05:17
+
+    [[terrible.regret-sisters-terrible]]
+
+    [[terrible.regret-sisters-terrible]]
+    bake = 0.8399
+    cross = 427
+    leather = [ 02:56:44.000030194, 1974-09-24 ]
+    nondescript-attempt-bore = 1900-07-03T04:56:46.000004029+07:22
+    rejoice = true
+
+# geese snow relation worried
+
+        [terrible.regret-sisters-terrible.ancient]
+        boiling-messy-stingy = { fabulous-wretched-mark = [], wall-familiar-furtive = 2003-09-16 }
+        cobweb-fix = 1988-05-07T07:01:15-10:34
+        excuse-gleaming = { familiar = [ true, 1929-01-01T13:47:11+02:44, 04:04:47.00000846 ] } # heavy cheerful
+        fix-acceptable-string = 15:39:49.000006614 # actually imperfect
+        hard-to-find = false
+        imperfect = 1960-11-24T22:00:37 # overjoyed
+        rabbit-terrible-innocent = [] # threatening
+        rabbit-train-ski = 0.6229 # profuse
+        wilderness-advise = 1982-08-20
+
+            [[terrible.regret-sisters-terrible.ancient.umbrella-worried]]
+            afraid = true # dreary
+
+                [terrible.regret-sisters-terrible.ancient.umbrella-worried.uptight-sisters-leather]
+                bore-tank-afraid = true # wretched curtain
+
+        [[terrible.regret-sisters-terrible.terrible-scene-surprise]]
+        prefer-legal = 428
+        relation-license-partner = [ true ] # playground
+
+    [[terrible.regret-sisters-terrible]]
+    glorious-adorable = 206 # curtain
+    grandfather = 76
+    ignore-cycle = 1956-07-22T01:39:24+03:39
+    messy = {} # draconian
+
+        [[terrible.regret-sisters-terrible.memory]] # curious memory
+        kindhearted-anxious-rotten = true
+        march-cheerful-view = { best-rice-want = 1978-08-26T22:05:21-00:49, spiritual = 1951-01-22T09:45:33-07:27, vessel-insidious = true } # gold
+        mark-sulky = 0.0597
+        pear = 1986-10-18T13:04:43-01:01 # three itch
+        remarkable-wistful = 1901-10-01
+        scatter-furtive-versed = 01:16:52
+        tank-reject = [ 12:09:18, {} ] # wall finger
+
+        [[terrible.regret-sisters-terrible.memory]]
+        babies-memory = [ { decisive = 15:35:50.000020612, stale-spicy = 0.1702 } ] # adhesive
+        blue-eyed-aromatic = 'curious birds terrible crowded'
+        close-cobweb-satisfy = [ {} ]
+        license = 0.9682 # lewd
+        reject-spiritual-taboo = ''
+        sulky-afraid = false
+        train-ghost-week = [ [ 0.6958, true ], 1942-02-15 ]
+
+        [[terrible.regret-sisters-terrible.memory]]
+        imperfect = [ 0.0689 ] # harm
+        three-string-tacky = 0.2109

--- a/include/pytomlpp/compilers.hpp
+++ b/include/pytomlpp/compilers.hpp
@@ -1,0 +1,61 @@
+#ifndef PYTOMLPP_COMPILERS_HPP
+#define PYTOMLPP_COMPILERS_HPP
+
+// clang
+#ifdef __clang__
+#define PYTOMLPP_CLANG __clang_major__
+#define PYTOMLPP_PRAGMA_CLANG(...) _Pragma(__VA_ARGS__)
+#else
+#define PYTOMLPP_CLANG 0
+#define PYTOMLPP_PRAGMA_CLANG(...)
+#endif
+
+// intel icc
+#ifdef __INTEL_COMPILER
+#define PYTOMLPP_ICC __INTEL_COMPILER
+#ifdef __ICL
+#define PYTOMLPP_ICC_CL PYTOMLPP_ICC
+#else
+#define PYTOMLPP_ICC_CL 0
+#endif
+#else
+#define PYTOMLPP_ICC 0
+#define PYTOMLPP_ICC_CL 0
+#endif
+
+// msvc
+// note: other compilers emulate MSVC; check must explicitly exclude them
+#if defined(_MSC_VER) && !PYTOMLPP_CLANG && !PYTOMLPP_ICC
+#define PYTOMLPP_MSVC _MSC_VER
+#define PYTOMLPP_PRAGMA_MSVC(...) __pragma(__VA_ARGS__)
+#else
+#define PYTOMLPP_MSVC 0
+#define PYTOMLPP_PRAGMA_MSVC(...)
+#endif
+
+// gcc
+// note: other compilers emulate GCC; check must explicitly exclude them
+#if defined(__GNUC__) && !PYTOMLPP_CLANG && !PYTOMLPP_ICC
+#define PYTOMLPP_GCC __GNUC__
+#define PYTOMLPP_PRAGMA_GCC(...) _Pragma(__VA_ARGS__)
+#else
+#define PYTOMLPP_GCC 0
+#define PYTOMLPP_PRAGMA_GCC(...)
+#endif
+
+#define PYTOMLPP_PUSH_OPTIMIZATIONS                                            \
+  PYTOMLPP_PRAGMA_MSVC(optimize("gt", on))                                     \
+  PYTOMLPP_PRAGMA_MSVC(runtime_checks("", off))                                \
+  PYTOMLPP_PRAGMA_MSVC(strict_gs_check(push, off))                             \
+  PYTOMLPP_PRAGMA_MSVC(inline_recursion(on))                                   \
+  PYTOMLPP_PRAGMA_MSVC(inline_depth(255))                                      \
+  static_assert(true)
+
+#define PYTOMLPP_POP_OPTIMIZATIONS                                             \
+  PYTOMLPP_PRAGMA_MSVC(inline_recursion(off))                                  \
+  PYTOMLPP_PRAGMA_MSVC(strict_gs_check(pop))                                   \
+  PYTOMLPP_PRAGMA_MSVC(runtime_checks("", restore))                            \
+  PYTOMLPP_PRAGMA_MSVC(optimize("", on))                                       \
+  static_assert(true)
+
+#endif // PYTOMLPP_COMPILERS_HPP

--- a/include/pytomlpp/pytomlpp.hpp
+++ b/include/pytomlpp/pytomlpp.hpp
@@ -23,12 +23,17 @@
 #endif
 
 // common includes
+#include <string>
+#include <sstream>
+#include <exception>
+#include <pybind11/pybind11.h>
 #if PYTOMLPP_USE_TL_OPTIONAL
 #include <optional.hpp>
 #endif
-#include <pybind11/pybind11.h>
-#include <sstream>
+#include "compilers.hpp"
+PYTOMLPP_PUSH_OPTIMIZATIONS;
 #include <tomlplusplus/include/toml++/toml.h>
+PYTOMLPP_POP_OPTIMIZATIONS;
 
 // namespace and type forward declarations
 namespace py = pybind11;

--- a/src/pytomlpp.cpp
+++ b/src/pytomlpp.cpp
@@ -1,11 +1,12 @@
 #define TOML_IMPLEMENTATION
-
 #include <pytomlpp/pytomlpp.hpp>
 #if PYTOMLPP_PROFILING
 #include <chrono>
 #include <iomanip>
 #include <pybind11/iostream.h>
 #endif // PYTOMLPP_PROFILING
+
+PYTOMLPP_PUSH_OPTIMIZATIONS;
 
 namespace {
 #if PYTOMLPP_PROFILING

--- a/src/type_casters.cpp
+++ b/src/type_casters.cpp
@@ -1,6 +1,8 @@
 #include <pytomlpp/pytomlpp.hpp>
 #include <datetime.h>
 
+PYTOMLPP_PUSH_OPTIMIZATIONS;
+
 namespace {
 void lazy_init_py_date_time() noexcept {
   if (PyDateTimeAPI)


### PR DESCRIPTION
also:
- update benchmark script to handle parse failures
- update benchmark data to better stress-test parsers
- added PEP 680 awareness to the benchmark script (`tomllib`)
- made the toml++ submodule shallow by default
- minor perf tweaks