### PR TITLE
Hotfix: Binary modes does not take encoding argument.

### DIFF
--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -32,7 +32,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
     """
     data = _impl.dumps(data)
     if mode == "wb":
-        enconding = None
+        encoding = None
         data = data.encode("utf-8")
     if hasattr(fl, "write"):
         fl.write(data)

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -27,15 +27,17 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
         data (Dict[Any, Any]): input data
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to write the file, support "w", "wt" (text) or "wb" (binary). Defaults to "w".
-        encoding (str): defaults to utf-8, if None, local encoding is selected.
+        encoding (str): defaults to utf-8, if None, local encoding is selected. 
+        NOTE: ``Binary mode does not take enconding argument.``
     """
     data = _impl.dumps(data)
     if mode == "wb":
+        enconding = None
         data = data.encode("utf-8")
     if hasattr(fl, "write"):
         fl.write(data)
         return
-    with open(fl, mode=mode, encoding=encoding or None) as fh:
+    with open(fl, mode=mode, encoding=encoding) as fh:
         fh.write(data)
 
 
@@ -61,11 +63,12 @@ def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = "utf-8
     Returns:
         Dict[Any, Any]: deserialised data
     """
-
+    if mode == "rb":
+        encoding = None
     if hasattr(fl, "read"):
         data = fl.read()
     else:
-        with open(fl, mode=mode, encoding=encoding or None) as fh:
+        with open(fl, mode=mode, encoding=encoding) as fh:
             data = fh.read()
     if isinstance(data, bytes):
         return _impl.loads(data.decode("utf-8"))

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -33,7 +33,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
     data = _impl.dumps(data)
     if mode == "wb":
         encoding = None
-        data = data.encode("utf-8")
+        data     = data.encode("utf-8")
     if hasattr(fl, "write"):
         fl.write(data)
         return

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -59,6 +59,7 @@ def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = "utf-8
     Args:
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to read the file, support "r", "rt" (text) or "rb" (binary). Defaults to "r".
+        encoding (str): defaults to utf-8, if None, local encoding is selected. 
         NOTE: ``If mode is binary mode, encoding optional argument will be negligible.``
 
     Returns:

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -1,7 +1,7 @@
 """Python wrapper for Toml++ IO methods."""
 
 import os
-from typing import Any, BinaryIO, Dict, TextIO, Union
+from typing import Any, BinaryIO, Dict, TextIO, Union, Optional
 
 from . import _impl
 
@@ -20,13 +20,14 @@ def dumps(data: Dict[Any, Any]) -> str:
     return _impl.dumps(data)
 
 
-def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w") -> None:
+def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: Optional[str] = "utf-8") -> None:
     """Serialise data to TOML file
 
     Args:
         data (Dict[Any, Any]): input data
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to write the file, support "w", "wt" (text) or "wb" (binary). Defaults to "w".
+        encoding (str): defaults to utf-8, if None, local encoding is selected.
     """
     data = _impl.dumps(data)
     if mode == "wb":
@@ -34,7 +35,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w") -> None:
     if hasattr(fl, "write"):
         fl.write(data)
         return
-    with open(fl, mode=mode) as fh:
+    with open(fl, mode=mode, encoding=encoding or None) as fh:
         fh.write(data)
 
 
@@ -50,7 +51,7 @@ def loads(data: str) -> Dict[Any, Any]:
     return _impl.loads(data)
 
 
-def load(fl: FilePathOrObject, mode: str = "r") -> Dict[Any, Any]:
+def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = "utf-8") -> Dict[Any, Any]:
     """Deserialise from TOML file to python dict.
 
     Args:
@@ -64,7 +65,7 @@ def load(fl: FilePathOrObject, mode: str = "r") -> Dict[Any, Any]:
     if hasattr(fl, "read"):
         data = fl.read()
     else:
-        with open(fl, mode=mode) as fh:
+        with open(fl, mode=mode, encoding=encoding or None) as fh:
             data = fh.read()
     if isinstance(data, bytes):
         return _impl.loads(data.decode("utf-8"))

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -28,7 +28,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to write the file, support "w", "wt" (text) or "wb" (binary). Defaults to "w".
         encoding (str): defaults to utf-8, if None, local encoding is selected. 
-        NOTE: ``Binary mode does not take enconding argument.``
+        NOTE: ``If mode is binary mode, encoding optional argument will be negligible.``
     """
     data = _impl.dumps(data)
     if mode == "wb":
@@ -59,6 +59,7 @@ def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = "utf-8
     Args:
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to read the file, support "r", "rt" (text) or "rb" (binary). Defaults to "r".
+        NOTE: ``If mode is binary mode, encoding optional argument will be negligible.``
 
     Returns:
         Dict[Any, Any]: deserialised data


### PR DESCRIPTION
As I said in a comment on the last PR, the problem was that certain tests were failing because they were passing the enconding argument as "utf-8" to binary modes, which do not accept enconding.