### PR TITLE
Add optional encoding parameter to load and dump functions

### DIFF
--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,10 +1,9 @@
 import timeit
 from pathlib import Path
 
-_parsers = []
+_parsers = [('pytomlpp', pytomlpp.loads)]
 
 import pytomlpp
-_parsers.append(('pytomlpp', pytomlpp.loads))
 
 try:
     import rtoml

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,9 +1,9 @@
 import timeit
 from pathlib import Path
 
-_parsers = [('pytomlpp', pytomlpp.loads)]
 
 import pytomlpp
+_parsers = [('pytomlpp', pytomlpp.loads)]
 
 try:
     import rtoml

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -32,7 +32,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
     """
     data = _impl.dumps(data)
     if mode == "wb":
-        enconding = None
+        encoding = None
         data = data.encode("utf-8")
     if hasattr(fl, "write"):
         fl.write(data)

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -27,15 +27,17 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
         data (Dict[Any, Any]): input data
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to write the file, support "w", "wt" (text) or "wb" (binary). Defaults to "w".
-        encoding (str): defaults to utf-8, if None, local encoding is selected.
+        encoding (str): defaults to utf-8, if None, local encoding is selected. 
+        NOTE: ``Binary mode does not take enconding argument.``
     """
     data = _impl.dumps(data)
     if mode == "wb":
+        enconding = None
         data = data.encode("utf-8")
     if hasattr(fl, "write"):
         fl.write(data)
         return
-    with open(fl, mode=mode, encoding=encoding or None) as fh:
+    with open(fl, mode=mode, encoding=encoding) as fh:
         fh.write(data)
 
 
@@ -61,11 +63,12 @@ def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = "utf-8
     Returns:
         Dict[Any, Any]: deserialised data
     """
-
+    if mode == "rb":
+        encoding = None
     if hasattr(fl, "read"):
         data = fl.read()
     else:
-        with open(fl, mode=mode, encoding=encoding or None) as fh:
+        with open(fl, mode=mode, encoding=encoding) as fh:
             data = fh.read()
     if isinstance(data, bytes):
         return _impl.loads(data.decode("utf-8"))

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -33,7 +33,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
     data = _impl.dumps(data)
     if mode == "wb":
         encoding = None
-        data = data.encode("utf-8")
+        data     = data.encode("utf-8")
     if hasattr(fl, "write"):
         fl.write(data)
         return

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -27,7 +27,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
         data (Dict[Any, Any]): input data
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to write the file, support "w", "wt" (text) or "wb" (binary). Defaults to "w".
-        encoding (str): defaults to None. Local enconding will be selected with``locale.getpreferredencoding(False)``
+        encoding (str): defaults to None. If None, local enconding will be selected. 
         NOTE: ``If mode is binary mode, encoding optional argument will be negligible.``
     """
     data = _impl.dumps(data)
@@ -38,7 +38,6 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
         return
     with open(fl, mode=mode, encoding=encoding) as fh:
        fh.write(data)
-
 
 
 def loads(data: str) -> Dict[Any, Any]:
@@ -59,7 +58,7 @@ def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = None) 
     Args:
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to read the file, support "r", "rt" (text) or "rb" (binary). Defaults to "r".
-        encoding (str): defaults to None. Local enconding will be selected with ``locale.getpreferredencoding(False)`` . 
+        encoding (str): defaults to None. If None, local enconding will be selected. 
         NOTE: ``If mode is binary mode, encoding optional argument will be negligible.``
           
     Returns:

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -59,6 +59,7 @@ def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = "utf-8
     Args:
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to read the file, support "r", "rt" (text) or "rb" (binary). Defaults to "r".
+        encoding (str): defaults to utf-8, if None, local encoding is selected. 
         NOTE: ``If mode is binary mode, encoding optional argument will be negligible.``
 
     Returns:

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -1,7 +1,7 @@
 """Python wrapper for Toml++ IO methods."""
 
 import os
-from typing import Any, BinaryIO, Dict, TextIO, Union
+from typing import Any, BinaryIO, Dict, TextIO, Union, Optional
 
 from . import _impl
 
@@ -20,13 +20,14 @@ def dumps(data: Dict[Any, Any]) -> str:
     return _impl.dumps(data)
 
 
-def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w") -> None:
+def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: Optional[str] = "utf-8") -> None:
     """Serialise data to TOML file
 
     Args:
         data (Dict[Any, Any]): input data
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to write the file, support "w", "wt" (text) or "wb" (binary). Defaults to "w".
+        encoding (str): defaults to utf-8, if None, local encoding is selected.
     """
     data = _impl.dumps(data)
     if mode == "wb":
@@ -34,7 +35,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w") -> None:
     if hasattr(fl, "write"):
         fl.write(data)
         return
-    with open(fl, mode=mode) as fh:
+    with open(fl, mode=mode, encoding=encoding or None) as fh:
         fh.write(data)
 
 
@@ -50,7 +51,7 @@ def loads(data: str) -> Dict[Any, Any]:
     return _impl.loads(data)
 
 
-def load(fl: FilePathOrObject, mode: str = "r") -> Dict[Any, Any]:
+def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = "utf-8") -> Dict[Any, Any]:
     """Deserialise from TOML file to python dict.
 
     Args:
@@ -64,7 +65,7 @@ def load(fl: FilePathOrObject, mode: str = "r") -> Dict[Any, Any]:
     if hasattr(fl, "read"):
         data = fl.read()
     else:
-        with open(fl, mode=mode) as fh:
+        with open(fl, mode=mode, encoding=encoding or None) as fh:
             data = fh.read()
     if isinstance(data, bytes):
         return _impl.loads(data.decode("utf-8"))

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -20,7 +20,7 @@ def dumps(data: Dict[Any, Any]) -> str:
     return _impl.dumps(data)
 
 
-def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: Optional[str] = "utf-8") -> None:
+def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: Optional[str] = None) -> None:
     """Serialise data to TOML file
 
     Args:
@@ -32,7 +32,6 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
     """
     data = _impl.dumps(data)
     if mode == "wb":
-        encoding = None
         data = data.encode("utf-8")
     if hasattr(fl, "write"):
         fl.write(data)
@@ -54,7 +53,7 @@ def loads(data: str) -> Dict[Any, Any]:
     return _impl.loads(data)
 
 
-def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = "utf-8") -> Dict[Any, Any]:
+def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = None) -> Dict[Any, Any]:
     """Deserialise from TOML file to python dict.
 
     Args:
@@ -66,8 +65,6 @@ def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = "utf-8
     Returns:
         Dict[Any, Any]: deserialised data
     """
-    if mode == "rb":
-        encoding = None
     if hasattr(fl, "read"):
         data = fl.read()
     else:

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -28,7 +28,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to write the file, support "w", "wt" (text) or "wb" (binary). Defaults to "w".
         encoding (str): defaults to utf-8, if None, local encoding is selected. 
-        NOTE: ``Binary mode does not take enconding argument.``
+        NOTE: ``If mode is binary mode, encoding optional argument will be negligible.``
     """
     data = _impl.dumps(data)
     if mode == "wb":
@@ -59,6 +59,7 @@ def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = "utf-8
     Args:
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to read the file, support "r", "rt" (text) or "rb" (binary). Defaults to "r".
+        NOTE: ``If mode is binary mode, encoding optional argument will be negligible.``
 
     Returns:
         Dict[Any, Any]: deserialised data

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -27,7 +27,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
         data (Dict[Any, Any]): input data
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to write the file, support "w", "wt" (text) or "wb" (binary). Defaults to "w".
-        encoding (str): defaults to utf-8, if None, local encoding is selected. 
+        encoding (str): defaults to None. Local enconding will be selected with``locale.getpreferredencoding(False)``
         NOTE: ``If mode is binary mode, encoding optional argument will be negligible.``
     """
     data = _impl.dumps(data)
@@ -59,7 +59,7 @@ def load(fl: FilePathOrObject, mode: str = "r", encoding: Optional[str] = None) 
     Args:
         fl (FilePathOrObject): file like object or path
         mode (str, optional): mode to read the file, support "r", "rt" (text) or "rb" (binary). Defaults to "r".
-        encoding (str): defaults to utf-8, if None, local encoding is selected. 
+        encoding (str): defaults to None. Local enconding will be selected with ``locale.getpreferredencoding(False)`` . 
         NOTE: ``If mode is binary mode, encoding optional argument will be negligible.``
           
     Returns:

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -37,7 +37,7 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
         fl.write(data)
         return
     with open(fl, mode=mode, encoding=encoding) as fh:
-       fh.write(data)
+        fh.write(data)
 
 
 def loads(data: str) -> Dict[Any, Any]:

--- a/src/pytomlpp/_io.py
+++ b/src/pytomlpp/_io.py
@@ -33,13 +33,12 @@ def dump(data: Dict[Any, Any], fl: FilePathOrObject, mode: str = "w", encoding: 
     data = _impl.dumps(data)
     if mode == "wb":
         encoding = None
-        data     = data.encode("utf-8")
+        data = data.encode("utf-8")
     if hasattr(fl, "write"):
         fl.write(data)
         return
     with open(fl, mode=mode, encoding=encoding) as fh:
        fh.write(data)
-
 
 
 

--- a/tests/python-tests/test_api.py
+++ b/tests/python-tests/test_api.py
@@ -11,6 +11,7 @@ except ImportError:
 
 from dateutil import parser as dateutil_parser
 
+# import pytomlpp
 import pytomlpp
 
 TOML_TESTS_SKIP = [

--- a/tests/python-tests/test_api.py
+++ b/tests/python-tests/test_api.py
@@ -11,7 +11,6 @@ except ImportError:
 
 from dateutil import parser as dateutil_parser
 
-# import pytomlpp
 import pytomlpp
 
 TOML_TESTS_SKIP = [


### PR DESCRIPTION
An optional ``encoding`` parameter has been added to the ``dump`` and ``load`` functions to provide more flexibility in specifying encoding, rather than always using the system default.